### PR TITLE
Fix bug on pages with predefined canvas background color

### DIFF
--- a/js/fokus.js
+++ b/js/fokus.js
@@ -46,6 +46,7 @@
 			overlay.style.top = 0;
 			overlay.style.zIndex = 2147483647;
 			overlay.style.pointerEvents = 'none';
+			overlay.style.background = 'transparent';
 
 			document.addEventListener( 'mousedown', onMouseDown, false );
 			document.addEventListener( 'keyup', onKeyUp, false );


### PR DESCRIPTION
In some pages with predefined canvas background color for canvas element like the website of the [Foundation framework](http://foundation.zurb.com/whats-new.php), script stopped working and only shows a colored canvas, I have fixed this issue by adding transparent background to the element, but because I dont know which js compressor is used to compress js file and build fokus.min.js, I dont changed it, so if you want to push my changes to your repository, please build that file first.
